### PR TITLE
Let df be Any

### DIFF
--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -1,6 +1,6 @@
 module LineSearches
 
-export AbstractDifferentiableFunction, LineSearchResults
+export LineSearchResults
 
 export clear!, alphatry, alphainit
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,7 +1,7 @@
 # Code used to use phi, a 1-parameter function induced by f and s
 # Need to pass s as an explicit parameter
 function alphatry{T}(alpha::T,
-                     df::AbstractDifferentiableFunction,
+                     df,
                      x::Array,
                      s::Array,
                      xtmp::Array,

--- a/src/backtracking_linesearch.jl
+++ b/src/backtracking_linesearch.jl
@@ -1,4 +1,4 @@
-function backtracking_linesearch!{T}(df::AbstractDifferentiableFunction,
+function backtracking_linesearch!{T}(df,
                                      x::Vector{T},
                                      s::Vector,
                                      x_scratch::Vector,

--- a/src/hz_linesearch.jl
+++ b/src/hz_linesearch.jl
@@ -54,7 +54,7 @@ display_nextbit = 14
 const DEFAULTDELTA = 0.1
 const DEFAULTSIGMA = 0.9
 
-function hz_linesearch!{T}(df::AbstractDifferentiableFunction,
+function hz_linesearch!{T}(df,
                            x::Array{T},
                            s::Array,
                            xtmp::Array,
@@ -285,7 +285,7 @@ function secant(lsr::LineSearchResults, ia::Integer, ib::Integer)
     return secant(lsr.alpha[ia], lsr.alpha[ib], lsr.slope[ia], lsr.slope[ib])
 end
 # phi
-function secant2!{T}(df::AbstractDifferentiableFunction,
+function secant2!{T}(df,
                      x::Array,
                      s::Array,
                      xtmp::Array,
@@ -378,7 +378,7 @@ end
 # Given a third point, pick the best two that retain the bracket
 # around the minimum (as defined by HZ, eq. 29)
 # b will be the upper bound, and a the lower bound
-function update!(df::AbstractDifferentiableFunction,
+function update!(df,
                  x::Array,
                  s::Array,
                  xtmp::Array,
@@ -428,7 +428,7 @@ function update!(df::AbstractDifferentiableFunction,
 end
 
 # HZ, stage U3 (with theta=0.5)
-function bisect!{T}(df::AbstractDifferentiableFunction,
+function bisect!{T}(df,
                     x::Array,
                     s::Array,
                     xtmp::Array,
@@ -475,7 +475,7 @@ function bisect!{T}(df::AbstractDifferentiableFunction,
 end
 
 # Define one-parameter function for line searches
-function linefunc!(df::AbstractDifferentiableFunction,
+function linefunc!(df,
                    x::Array,
                    s::Array,
                    alpha::Real,

--- a/src/interpolating_linesearch.jl
+++ b/src/interpolating_linesearch.jl
@@ -1,7 +1,7 @@
 # TODO: Optimize for fg! calls
 # TODO: Implement safeguards
 
-function interpolating_linesearch!{T}(df::AbstractDifferentiableFunction,
+function interpolating_linesearch!{T}(df,
                                       x::Vector,
                                       p::Vector,
                                       x_new::Vector,

--- a/src/mt_linesearch.jl
+++ b/src/mt_linesearch.jl
@@ -132,7 +132,7 @@
 # TODO: Decide whether to update x, f, g and info
 #       or just return step and nfev and let existing code do its job
 
-function mt_linesearch!{T}(df::AbstractDifferentiableFunction,
+function mt_linesearch!{T}(df,
                          x::Vector,
                          s::Vector,
                          new_x::Vector,

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,3 @@
-abstract AbstractDifferentiableFunction
-
 # A cache for results from line search methods (to avoid recomputation)
 type LineSearchResults{T}
     alpha::Vector{T}
@@ -35,16 +33,16 @@ type LinesearchException{T<:Real} <: Exception
     lsr::LineSearchResults
 end
 
-immutable LSDifferentiableFunction <: LineSearches.AbstractDifferentiableFunction
+immutable DifferentiableFunction
     f::Function
     g!::Function
     fg!::Function
 end
 
-function LSDifferentiableFunction(f::Function, g!::Function)
+function DifferentiableFunction(f::Function, g!::Function)
     function fg!(x::Array, storage::Array)
         g!(x, storage)
         return f(x)
     end
-    return LSDifferentiableFunction(f, g!, fg!)
+    return DifferentiableFunction(f, g!, fg!)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ function g!(x, out)
     out[:] = 2x
 end
 
-df = LineSearches.LSDifferentiableFunction(f,g!)
+df = LineSearches.DifferentiableFunction(f,g!)
 
 for (i, linesearch!) in enumerate(lsfunctions)
     println("Testing $(string(linesearch!))")


### PR DESCRIPTION
Ref discussion in JuliaOpt/Optim.jl#277. 
It is unlikely that the linesearch algorithms will get ambiguity clashes with other packages, so we remove the `AbstractDifferentiableFunction` type requirement. 
