### PR TITLE
Backtracking line search with interpolation

### DIFF
--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -5,7 +5,7 @@ export LineSearchResults
 export clear!, alphatry, alphainit
 
 export hz_linesearch!, backtracking_linesearch!, interpolating_linesearch!,
-    mt_linesearch!
+    mt_linesearch!, interpbacktrack_linesearch!
 
 include("types.jl")
 include("api.jl")

--- a/src/backtracking_linesearch.jl
+++ b/src/backtracking_linesearch.jl
@@ -7,6 +7,8 @@ f(0), f'(0), f(α) has a minimiser α' in the open interval (0, α). More strong
 there exists a factor ρ = ρ(c₁) such that α' ≦ ρ α. This makes
 the `interpbacktrack_linesearch!` a backtracking type linesearch.
 
+This is a modification of the algorithm described in Nocedal Wright (2nd ed), Sec. 3.5.
+
 **Default Parameters**
 
 * `c1 = 0.2` : Armijo condition

--- a/src/backtracking_linesearch.jl
+++ b/src/backtracking_linesearch.jl
@@ -62,8 +62,8 @@ function backtracking_linesearch!{T}(df,
     if interp   # this means we are coming from interpbacktrack_linesearch!
        backtrack_condition = 1.0 - 1.0/(2*rho) # want guaranteed backtrack factor
        if c1 >= backtrack_condition
-           warning("""The Armijo constant c1 is too large; replacing it with
-                      $(backtrack_condition)""")
+           warn("""The Armijo constant c1 is too large; replacing it with
+                   $(backtrack_condition)""")
            c1 = backtrack_condition
        end
        if rho <= mindecfact

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,9 @@ using LineSearches
 using Base.Test
 
 lsfunctions = [hz_linesearch!, interpolating_linesearch!,
-               mt_linesearch!, backtracking_linesearch!]
-lsalphas = [0.5,0.5,0.49995,0.9]
+               mt_linesearch!, backtracking_linesearch!,
+               interpbacktrack_linesearch!]
+lsalphas = [0.5,0.5,0.49995,0.9,0.5]
 
 f(x) = vecdot(x,x)
 


### PR DESCRIPTION
This PR adds a second backtracking line search, `interpbacktrack_linesearch!` which, instead of an a *= rho update performs an interpolation step; this is highly efficient for some problems; see QCG and QLBFGS in the following figure (from my own research); 
<img width="543" alt="optim" src="https://cloud.githubusercontent.com/assets/7688515/19221917/5d9fa264-8e44-11e6-854c-46c4c973e745.png">

It also outperforms HZ and MT line-search for some more standard model problems.  In general, it is no worse than standard backtracking, which I left only for the sake of compatibility. I would actually recommend to remove standard backtracking altogether and replace it with `interpbacktrack`.
