### PR TITLE
WIP: Throw LineSearchException on max iterations

### DIFF
--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -2,7 +2,7 @@ isdefined(Base, :__precompile__) && __precompile__()
 
 module LineSearches
 
-export LineSearchResults
+export LineSearchResults, LineSearchException
 
 export clear!, alphatry, alphainit
 

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -102,7 +102,8 @@ function backtracking!{T}(df,
 
         # Ensure termination
         if iteration > iterations
-            error("Too many iterations in backtracking!")
+            throw(LineSearchException("Linesearch failed to converge, reached maximum iterations $(linesearchmax).",
+                                      lsr.alpha[ia], f_calls, g_calls,lsr))
         end
 
         # Shrink proposed step-size:

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -5,3 +5,4 @@
 @deprecate backtracking_linesearch! backtracking!
 @deprecate interpbacktrack_linesearch! interpbacktrack!
 @deprecate interpolating_linesearch! strongwolfe!
+@deprecate LinesearchException LineSearchException

--- a/src/hagerzhang.jl
+++ b/src/hagerzhang.jl
@@ -258,7 +258,11 @@ function hagerzhang!{T}(df,
         end
         iter += 1
     end
-    error("Linesearch failed to converge")
+
+    throw(LineSearchException("Linesearch failed to converge, reached maximum iterations $(linesearchmax).",
+                              lsr.alpha[ia], f_calls, g_calls,lsr))
+
+
 end
 
 # Check Wolfe & approximate Wolfe

--- a/src/morethuente.jl
+++ b/src/morethuente.jl
@@ -158,7 +158,7 @@ function morethuente!{T}(df,
 
     if n <= 0 || stp <= 0.0 || f_tol < 0.0 || gtol < 0.0 ||
         x_tol < 0.0 || stpmin < 0.0 || stpmax < stpmin || maxfev <= 0
-        throw(ArgumentError("Invalid parameters to mure_thuente_line_search"))
+        throw(ArgumentError("Invalid parameters to morethuente"))
     end
 
     # Count function and gradient calls
@@ -255,7 +255,7 @@ function morethuente!{T}(df,
         # Test for convergence.
         #
 
-        # What's does info_cstep stand for?
+        # What does info_cstep stand for?
 
         if (bracketed && (stp <= stmin || stp >= stmax)) || info_cstep == 0
             info = 6

--- a/src/types.jl
+++ b/src/types.jl
@@ -25,7 +25,7 @@ function clear!(lsr::LineSearchResults)
     # nfailures is deliberately not set to 0
 end
 
-type LinesearchException{T<:Real} <: Exception
+type LineSearchException{T<:Real} <: Exception
     message::AbstractString
     alpha::T
     f_update::Int


### PR DESCRIPTION
The hagerzhang and backtracking algorithms have a maximum iterations limit. 
Currently, it just throws an error. It would be more useful to throw an exception that stores the status of the linesearch.
