### PR TITLE
RFC: Implement cubic backtracking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# LineSearches v0.1.3 release notes
+* The backtracking algorithm now performs quadratic or cubic interpolations
+[#20](https://github.com/anriseth/LineSearches.jl/pull/20)
+
 # LineSearches v0.1.1 release notes
 * Hagerzhang and Backtrack now throw LineSearchExceptions
 [#19](https://github.com/anriseth/LineSearches.jl/pull/19)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ but has now been separated out to its own package.
   by Hager and Zhang, 2006)
 * `morethuente!` (From the algorithm in More and Thuente, 1994)
 * `backtracking!` (Described in Nocedal and Wright, 2006)
-* `interpbacktracking!` (Nocedal and Wright)
 * `strongwolfe!` (Nocedal and Wright)
 
 

--- a/src/LineSearches.jl
+++ b/src/LineSearches.jl
@@ -9,7 +9,7 @@ export LineSearchResults, LineSearchException
 export clear!, alphatry, alphainit
 
 export hagerzhang!, backtracking!, strongwolfe!,
-    morethuente!, interpbacktrack!
+    morethuente!, bt2!, bt3!
 
 include("types.jl")
 include("api.jl")

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -9,6 +9,38 @@ there exists a factor ρ = ρ(c₁) such that α' ≦ ρ α.
 This is a modification of the algorithm described in Nocedal Wright (2nd ed), Sec. 3.5.
 """
 
+bt3!{T}(df,
+        x::Vector{T},
+        s::Vector,
+        x_scratch::Vector,
+        gr_scratch::Vector,
+        lsr::LineSearchResults,
+        alpha::Real = 1.0,
+        mayterminate::Bool = false,
+        c1::Real = 1e-4,
+        rhohi::Real = 0.5,
+        rholo::Real = 0.1,
+        iterations::Integer = 1_000) =
+            backtracking!(df,x,s,x_scratch,gr_scratch,
+                          lsr,alpha,mayterminate,c1,
+                          rhohi,rholo,iterations,3)
+bt2!{T}(df,
+        x::Vector{T},
+        s::Vector,
+        x_scratch::Vector,
+        gr_scratch::Vector,
+        lsr::LineSearchResults,
+        alpha::Real = 1.0,
+        mayterminate::Bool = false,
+        c1::Real = 1e-4,
+        rhohi::Real = 0.5,
+        rholo::Real = 0.1,
+        iterations::Integer = 1_000) =
+            backtracking!(df,x,s,x_scratch,gr_scratch,
+                          lsr,alpha,mayterminate,c1,
+                          rhohi,rholo,iterations,2)
+
+
 function backtracking!{T}(df,
                           x::Vector{T},
                           s::Vector,

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -3,6 +3,6 @@
 @deprecate hz_linesearch! hagerzhang!
 @deprecate mt_linesearch! morethuente!
 @deprecate backtracking_linesearch! backtracking!
-@deprecate interpbacktrack_linesearch! interpbacktrack!
+@deprecate interpbacktrack_linesearch! backtracking!
 @deprecate interpolating_linesearch! strongwolfe!
 @deprecate LinesearchException LineSearchException

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -3,6 +3,7 @@
 @deprecate hz_linesearch! hagerzhang!
 @deprecate mt_linesearch! morethuente!
 @deprecate backtracking_linesearch! backtracking!
-@deprecate interpbacktrack_linesearch! backtracking!
+@deprecate interpbacktrack_linesearch! bt2!
 @deprecate interpolating_linesearch! strongwolfe!
 @deprecate LinesearchException LineSearchException
+@deprecate interpbacktrack! bt2!

--- a/test/alphacalc.jl
+++ b/test/alphacalc.jl
@@ -1,5 +1,5 @@
 let
-    lsalphas = [0.5,0.5,0.49995,0.9,0.5]
+    lsalphas = [0.5,0.5,0.49995,0.5,0.5,0.5]
 
     f(x) = vecdot(x,x)
     function g!(x, out)

--- a/test/backtracking.jl
+++ b/test/backtracking.jl
@@ -1,0 +1,15 @@
+import Optim
+
+# This test checks the functionality cubic interpolation functionality
+# in backtracking!
+# The Himmelblau function converges, but require multiple iterations in
+# some of the linesearches.
+
+let
+    name = "Himmelblau"
+    prob = Optim.UnconstrainedProblems.examples[name]
+    res = Optim.optimize(prob.f, prob.initial_x, Optim.BFGS(linesearch=LineSearches.bt3!),
+                         Optim.Options(autodiff = true))
+
+    @assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Base.Test
 
 lsfunctions = (hagerzhang!, strongwolfe!,
                morethuente!, backtracking!,
-               interpbacktrack!)
+               bt2!, bt3!)
 
 println("Running tests:")
 my_tests = [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,8 @@ lsfunctions = (hagerzhang!, strongwolfe!,
 println("Running tests:")
 my_tests = [
     "alphacalc.jl",
-    "optim.jl"
+    "optim.jl",
+    "backtracking.jl"
 ]
 
 for my_test in my_tests


### PR DESCRIPTION
I've updated the backtracking algorithm to use either quadratic or cubic interpolation as described in Nocedal and Wright. Parameters are taken from there and from "Numerical Methods for Unconstrained Optimization and Nonlinear Equations" by Dennis and Schnabel, page 325.

This might break people's code, as I've updated the parameter list list for the algorithm (sorting out #9 will make changes like this much smoother)

Closes #13