### PR TITLE
Store initial alpha step

### DIFF
--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -81,6 +81,7 @@ function backtracking!{T}(df,
     @simd for i in 1:n
         @inbounds x_scratch[i] = x[i] + alpha * s[i]
     end
+    push!(lsr.alpha, alpha)
 
     # Backtrack until we satisfy sufficient decrease condition
     f_x_scratch = df.f(x_scratch)
@@ -134,8 +135,8 @@ function backtracking!{T}(df,
 
         # Evaluate f(x) at proposed position
         f_x_scratch = df.f(x_scratch)
-        push!(lsr.value, f_x_scratch)
         f_calls += 1
+        push!(lsr.value, f_x_scratch)
     end
 
     return alpha, f_calls, g_calls

--- a/test/backtracking.jl
+++ b/test/backtracking.jl
@@ -10,6 +10,5 @@ let
     prob = Optim.UnconstrainedProblems.examples[name]
     res = Optim.optimize(prob.f, prob.initial_x, Optim.BFGS(linesearch=LineSearches.bt3!),
                          Optim.Options(autodiff = true))
-
-    @assert norm(Optim.minimizer(res) - prob.solutions) < 1e-2
+    @assert Optim.minimum(res) < prob.f(prob.solutions) + 1e-2
 end


### PR DESCRIPTION
bt3! has a serious bug, as it does not store the initial step length. The first cubic interpolation then falsely uses `alpha0 = 0`, as all the Optim solvers set `lsr.alpha[1] = zero(T)`